### PR TITLE
Fix to run in windows (wip)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -36,7 +36,7 @@
             },
             "msvs_settings": {
               "VCCLCompilerTool": {
-                "AdditionalOptions": ["/arch:AVX2", "/mavx2", "/mavx", "/mbmi", "/mpclmul"]
+                "AdditionalOptions": ["/std:c++17", "/arch:AVX2"]
               }
             },
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],


### PR DESCRIPTION
Fix for #1, still a few problems though:

- [x] Figure out causes
  - [x] Warnings C4244, C4309 etc
  - [x] `/benchmark/benchmark.js` just exits / calling simdjson.parse(something) just exits node process, no warnings / error

```
C:\simdjson_nodejs>yarn
yarn install v1.13.0-20181107.1254
warning package-lock.json found. Your project contains lock files generated by t
ools other than Yarn. It is advised not to mix package managers in order to avoi
d resolution inconsistencies caused by unsynchronized lock files. To clear this
warning, remove package-lock.json.
[1/4] Resolving packages...
success Already up-to-date.
$ node-gyp rebuild
gyp info it worked if it ends with ok
gyp info using node-gyp@3.8.0
gyp info using node@10.10.0 | win32 | x64
gyp info spawn C:\Python27\python.exe
gyp info spawn args [ 'C:\\simdjson_nodejs\\node_modules\\node-gyp\\gyp\\gyp_mai
n.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'msvs',
gyp info spawn args   '-G',
gyp info spawn args   'msvs_version=2015',
gyp info spawn args   '-I',
gyp info spawn args   'C:\\simdjson_nodejs\\build\\config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   'C:\\simdjson_nodejs\\node_modules\\node-gyp\\addon.gypi',

gyp info spawn args   '-I',
gyp info spawn args   'C:\\Users\\1234\\.node-gyp\\10.10.0\\include\\node\\commo
n.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=C:\\Users\\1234\\.node-gyp\\10.10.0',
gyp info spawn args   '-Dnode_gyp_dir=C:\\simdjson_nodejs\\node_modules\\node-gy
p',
gyp info spawn args   '-Dnode_lib_file=C:\\Users\\1234\\.node-gyp\\10.10.0\\<(ta
rget_arch)\\node.lib',
gyp info spawn args   '-Dmodule_root_dir=C:\\simdjson_nodejs',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'C:\\simdjson_nodejs\\build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp info spawn C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MS
Build\15.0\Bin\MSBuild.exe
gyp info spawn args [ 'build/binding.sln',
gyp info spawn args   '/clp:Verbosity=minimal',
gyp info spawn args   '/nologo',
gyp info spawn args   '/p:Configuration=Release;Platform=x64' ]
Building the projects in this solution one at a time. To enable parallel build,
please add the "/m" switch.
  main.cpp
  nonavx2.cpp
  win_delay_load_hook.cc
     Creating library C:\simdjson_nodejs\build\Release\simdjson.lib and object
  C:\simdjson_nodejs\build\Release\simdjson.exp
  Generating code
  All 79 functions were compiled because no usable IPDB/IOBJ from previous comp
  ilation was found.
  Finished generating code
  simdjson.vcxproj -> C:\simdjson_nodejs\build\Release\\simdjson.node
  main.cpp
  simdjson.cpp
  bindings.cpp
  win_delay_load_hook.cc
c:\simdjson_nodejs\simdjson\src\simdjson.h(42): warning C4244: 'return': conver
sion from 'unsigned __int64' to 'int', possible loss of data (compiling source
file ..\simdjson\src\simdjson.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxp
roj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(46): warning C4244: 'return': conver
sion from 'unsigned __int64' to 'int', possible loss of data (compiling source
file ..\simdjson\src\simdjson.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxp
roj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(42): warning C4244: 'return': conver
sion from 'unsigned __int64' to 'int', possible loss of data (compiling source
file ..\simdjson\main.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(46): warning C4244: 'return': conver
sion from 'unsigned __int64' to 'int', possible loss of data (compiling source
file ..\simdjson\main.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(42): warning C4244: 'return': conver
sion from 'unsigned __int64' to 'int', possible loss of data (compiling source
file ..\simdjson\bindings.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(46): warning C4244: 'return': conver
sion from 'unsigned __int64' to 'int', possible loss of data (compiling source
file ..\simdjson\bindings.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35592): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35644): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35646): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35649): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35651): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35677): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35691): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\src\simdjson.cpp
) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36473): warning C4244: 'initializing
': conversion from 'int64_t' to 'int', possible loss of data (compiling source
file ..\simdjson\src\simdjson.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxp
roj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36557): warning C4146: unary minus o
perator applied to unsigned type, result still unsigned (compiling source file
..\simdjson\src\simdjson.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36652): warning C4244: 'initializing
': conversion from '__int64' to 'int', possible loss of data (compiling source
file ..\simdjson\src\simdjson.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxp
roj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36721): warning C4244: 'initializing
': conversion from 'int64_t' to 'double', possible loss of data (compiling sour
ce file ..\simdjson\src\simdjson.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.v
cxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(163): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(246): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(258): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35592): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35644): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35646): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35649): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35651): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35677): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35691): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\main.cpp) [C:\si
mdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35592): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35644): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35646): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35649): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35651): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35677): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(35691): warning C4309: 'argument': t
runcation of constant value (compiling source file ..\simdjson\bindings.cpp) [C
:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36473): warning C4244: 'initializing
': conversion from 'int64_t' to 'int', possible loss of data (compiling source
file ..\simdjson\main.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36557): warning C4146: unary minus o
perator applied to unsigned type, result still unsigned (compiling source file
..\simdjson\main.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36652): warning C4244: 'initializing
': conversion from '__int64' to 'int', possible loss of data (compiling source
file ..\simdjson\main.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36721): warning C4244: 'initializing
': conversion from 'int64_t' to 'double', possible loss of data (compiling sour
ce file ..\simdjson\main.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36473): warning C4244: 'initializing
': conversion from 'int64_t' to 'int', possible loss of data (compiling source
file ..\simdjson\bindings.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36557): warning C4146: unary minus o
perator applied to unsigned type, result still unsigned (compiling source file
..\simdjson\bindings.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36652): warning C4244: 'initializing
': conversion from '__int64' to 'int', possible loss of data (compiling source
file ..\simdjson\bindings.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.h(36721): warning C4244: 'initializing
': conversion from 'int64_t' to 'double', possible loss of data (compiling sour
ce file ..\simdjson\bindings.cpp) [C:\simdjson_nodejs\build\simdjson-avx2.vcxpr
oj]
c:\simdjson_nodejs\simdjson\bindings.cpp(72): warning C4244: 'argument': conver
sion from 'int64_t' to 'double', possible loss of data [C:\simdjson_nodejs\buil
d\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(439): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(494): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(617): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(672): warning C4309: 'argument': t
runcation of constant value [C:\simdjson_nodejs\build\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(850): warning C4244: '=': conversi
on from 'uint64_t' to 'uint32_t', possible loss of data [C:\simdjson_nodejs\bui
ld\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(862): warning C4244: '=': conversi
on from 'uint64_t' to 'uint32_t', possible loss of data [C:\simdjson_nodejs\bui
ld\simdjson-avx2.vcxproj]
c:\simdjson_nodejs\simdjson\src\simdjson.cpp(874): warning C4244: '=': conversi
on from 'uint64_t' to 'uint32_t', possible loss of data [C:\simdjson_nodejs\bui
ld\simdjson-avx2.vcxproj]
     Creating library C:\simdjson_nodejs\build\Release\simdjson-avx2.lib and ob
  ject C:\simdjson_nodejs\build\Release\simdjson-avx2.exp
  Generating code
  All 539 functions were compiled because no usable IPDB/IOBJ from previous com
  pilation was found.
  Finished generating code
  simdjson-avx2.vcxproj -> C:\simdjson_nodejs\build\Release\\simdjson-avx2.node
gyp info ok
Done in 8.35s.
```